### PR TITLE
Update default_input_commands.py

### DIFF
--- a/ark/default_input_commands.py
+++ b/ark/default_input_commands.py
@@ -77,7 +77,7 @@ class DefaultInputCommands(object):
     def _cmd_restart(text):
         if text.lower().strip() == 'restart now':
             out('Issuing IMMEDIDATE server restart')
-            Rcon.broadcast('Restarting the server!', Rcon.response_callback_response_only)
+            Rcon.broadcast('Restarting the server!', None)
             ServerControl.restart_server()
             return
 


### PR DESCRIPTION
Rcon.Broadcast(text, callback) seems to only accept None as callback and does works otherwise
